### PR TITLE
fix(drag-n-drop): fix drop error in Firefox

### DIFF
--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -45,13 +45,12 @@ export default {
         this.dragCounter--;
       }
     },
-    onDrop(event) {
+    onDrop() {
       if (!this.treeModel.isDragging()) {
         return;
       }
       this.dragCounter = 0;
       this.treeModel.dropOnNode(this.node.id);
-      event.dataTransfer.clearData();
     }
   }
 };

--- a/src/components/__tests__/FinderListDropZone.test.js
+++ b/src/components/__tests__/FinderListDropZone.test.js
@@ -106,11 +106,7 @@ describe("FinderListDropZone", () => {
           dragEnabled: true
         }
       });
-      wrapper.trigger("drop", {
-        dataTransfer: {
-          clearData: jest.fn()
-        }
-      });
+      wrapper.trigger("drop");
       expect(treeModel.dropOnNode).toHaveBeenCalledWith("test111");
     });
 


### PR DESCRIPTION
Fix "Modifications are not allowed for this document" error in Firefox.
This issue was caused by a `DataTransfer.clearData()` call in the `drop` handler. Yet the [MDN doc](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/clearData) explains:

> This method can only be used in the handler for the `dragstart` event, because that's the only time the drag operation's data store is writeable.

So I remove this call that's not needed.