### PR TITLE
fix(ui): fix height of lists

### DIFF
--- a/docs/.vuepress/components/FinderExample.vue
+++ b/docs/.vuepress/components/FinderExample.vue
@@ -86,6 +86,6 @@ export default {
 <style lang="scss" scoped>
 .tree-container {
   margin: 20px 0;
-  min-height: 200px;
+  min-height: 250px;
 }
 </style>

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -106,10 +106,12 @@ export default {
 .tree-container {
   overflow-x: auto;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .list-container {
     display: flex;
-    height: 100%;
+    flex: 1;
   }
 }
 </style>

--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -90,7 +90,7 @@ export default {
   display: flex;
   flex-direction: column;
   min-width: 250px;
-  height: 100%;
+  min-height: 100%;
   border-right: solid 1px #ccc;
   overflow: auto;
   flex-shrink: 0;


### PR DESCRIPTION
This MR fix the height of the children lists: currently, lists don't fill the height of the tree container.