### PR TITLE
Add `expand` method in Finder API

### DIFF
--- a/docgen.config.js
+++ b/docgen.config.js
@@ -14,6 +14,7 @@ module.exports = {
   templates: {
     component: (renderedUsage, doc) =>
       templates.component({ renderedUsage, doc }),
-    events: events => templates.events({ events })
+    events: events => templates.events({ events }),
+    methods: methods => templates.methods({ methods })
   }
 };

--- a/docs/templates/events.dot
+++ b/docs/templates/events.dot
@@ -4,14 +4,16 @@
 
 {{ const { description, properties = [] } = it.events[eventName]; }}
 
-### `{{= eventName}}`
+### {{= eventName}}
 
 {{= description}}
 
 {{? properties.length > 0}}
-**Properties:**
+#### Properties
 
-{{~ properties :property}}{{ const t = property.type.names ? property.type.names.join(" ") : ""; }}- **{{= property.name}}**{{? t}} - `{{= t}}`{{?}}: {{= property.description}}
+| Name | Type | Description |
+|------|------|-------------|
+{{~ properties :property}}| `{{= property.name}}` | {{ const t = property.type.names ? property.type.names.join(" ") : ""; }} {{? t}} `{{= t}}`{{?}} | {{= property.description}} |
 {{~}}
 
 {{?}}

--- a/docs/templates/methods.dot
+++ b/docs/templates/methods.dot
@@ -1,0 +1,22 @@
+## Methods
+
+{{~it.methods :method}}
+
+{{ const { name, description, tags, params = [] } = method; }}
+
+
+### {{= name}}
+
+{{= description}}
+
+{{? params.length > 0}}
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+{{~ params :param}}| `{{= param.name}}` | {{= param.type ? `\`${param.type.name}\`` : '' }}  | {{= param.description}} |
+{{~}}
+
+{{?}}
+
+{{~}}

--- a/docs/templates/methods.dot
+++ b/docs/templates/methods.dot
@@ -3,9 +3,9 @@
 {{~it.methods :method}}
 
 {{ const { name, description, tags, params = [] } = method; }}
+{{ const sinceTag = tags.since && tags.since.length > 0 ? tags.since[0].description : undefined ;}}
 
-
-### {{= name}}
+### {{= name}} {{? sinceTag }}<Badge text="{{= sinceTag}}"/>{{?}}
 
 {{= description}}
 

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -181,6 +181,26 @@ export default {
       });
     });
   },
+  methods: {
+    /**
+     * Set a given item expanded.
+     *
+     * ```html
+     * <Finder :tree="tree" ref="myFinder" />
+     * ```
+     *
+     * ```js
+     * this.$refs.myFinder.expand('item111');
+     * ```
+     *
+     *
+     * @param {string} itemId ID of the item to expand
+     * @public
+     */
+    expand(itemId) {
+      this.treeModel.expandNode(itemId);
+    }
+  },
   render(h) {
     return (
       <div class="tree-container">

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -193,9 +193,9 @@ export default {
      * this.$refs.myFinder.expand('item111');
      * ```
      *
-     *
      * @param {string} itemId ID of the item to expand
      * @public
+     * @since 1.6.0
      */
     expand(itemId) {
       this.treeModel.expandNode(itemId);

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -200,4 +200,28 @@ describe("Finder", () => {
       ]);
     });
   });
+
+  describe("API", () => {
+    describe("#expand", () => {
+      it("should expand the given item and emit the `expand` event", () => {
+        const wrapper = mount(Finder, {
+          propsData: {
+            tree,
+            selectable: true
+          }
+        });
+
+        wrapper.vm.expand("test112");
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.emitted().expand).toEqual([
+          [
+            {
+              expanded: ["test1", "test11", "test112"]
+            }
+          ]
+        ]);
+      });
+    });
+  });
 });

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Finder API #expand should expand the given item and emit the \`expand\` event 1`] = `
+<div class="tree-container">
+  <div class="list-container">
+    <div class="list">
+      <div draggable="false" class="item expanded"><input type="checkbox">
+        <div item="[object Object]" class="inner-item">Test 11</div>
+        <div class="arrow"></div>
+      </div>
+      <div draggable="false" class="item"><input type="checkbox">
+        <div item="[object Object]" class="inner-item">Test 12</div>
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Finder Drag & Drop should match snapshot 1`] = `
 <div class="tree-container">
   <div class="list-container">


### PR DESCRIPTION
This MR a new method in the `Finder` API:
 
## expand

Set a given item expanded.

```html
<Finder :tree="tree" ref="myFinder" />
```

```js
this.$refs.myFinder.expand("item111");
```

#### Parameters

| Name     | Type     | Description              |
| -------- | -------- | ------------------------ |
| `itemId` | `string` | ID of the item to expand |