### PR TITLE
feat(theme): add theme prop

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -2,6 +2,41 @@
 
 Vue Finder provides some options to customize its look.
 
+## Theming
+
+The `Finder` component accepts a `theme` prop that allows to customize some CSS properties:
+
+```html
+<Finder :tree="tree" :theme="theme" />
+```
+
+```js
+// ...
+data() {
+  return {
+    theme: {
+      primaryColor: "#2196f3",
+      arrowColor: "black",
+      separatorColor: "#ccc",
+      separatorWidth: "1px",
+      dropZoneBgColor: "rgba(33, 150, 243, 0.2)",
+      draggedItemBgColor: "rgba(33, 150, 243, 0.5)"
+    }
+  }
+}
+```
+
+Here are the available properties:
+
+| Name                 | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `primaryColor`       | Primary color used for expanded items, dropzone borders...   |
+| `arrowColor`         | Color of arrows in expandable items                          |
+| `separatorColor`     | Border color of separators between lists                     |
+| `separatorWidth`     | Width value of separators between lists                      |
+| `dropZoneBgColor`    | Background color of drop zones (visible when Drag & Drop)    |
+| `draggedItemBgColor` | Background color of dragged items (visible when Drag & Drop) |
+
 ## Item component
 
 You can define a component to render items with the `itemComponent` prop. This component requires a `item` prop, that will
@@ -18,7 +53,7 @@ data() {
     itemComponent: {
       props: ["item"],
       template:
-        '<div style="color: blue"><em>Name:</em> <strong>{{ item.label }}</strong></div>'
+        "<div style="color: blue"><em>Name:</em> <strong>{{ item.label }}</strong></div>"
     }
   }
 }
@@ -37,7 +72,7 @@ You can also use a `render` function (in this case the runtime-only build is eno
 itemComponent: {
   props: ["item"],
   render(h) {
-    return h('div', this.item)
+    return h("div", this.item)
   }
 }
 ```

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -20,7 +20,8 @@ function renderTree(h, context, item) {
   );
 
   const options = {
-    itemComponent: context.itemComponent
+    itemComponent: context.itemComponent,
+    theme: context.theme
   };
 
   const itemList = (
@@ -90,6 +91,24 @@ export default {
     itemComponent: {
       type: Function,
       default: undefined
+    },
+    /**
+     * Styling options.
+     *
+     * ```js
+     * const theme = {
+     *   primaryColor: '#2196f3',
+     *   arrowColor: 'black',
+     *   separatorColor: '#ccc',
+     *   separatorWidth: '1px',
+     *   dropZoneBgColor: 'rgba(33, 150, 243, 0.2)',
+     *   draggedItemBgColor: 'rgba(33, 150, 243, 0.5)',
+     * };
+     * ```
+     */
+    theme: {
+      type: Object,
+      default: () => ({})
     },
     /**
      * Duration of the scroll animation (in milliseconds).

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -7,6 +7,18 @@
       dragged,
       'drag-over': dragOver
     }"
+    :style="{
+      ...(expanded &&
+        theme.primaryColor && { backgroundColor: theme.primaryColor }),
+      ...(dragged &&
+        theme.draggedItemBgColor && {
+          backgroundColor: theme.draggedItemBgColor
+        }),
+      ...(dragOver &&
+        theme.primaryColor && { borderColor: theme.primaryColor }),
+      ...(dragOver &&
+        theme.dropZoneBgColor && { backgroundColor: theme.dropZoneBgColor })
+    }"
     :draggable="dragEnabled"
     @dragenter="onDragEnter"
     @dragleave="onDragLeave"
@@ -27,7 +39,13 @@
     <component :is="itemComponent" class="inner-item" :item="node">
       <slot />
     </component>
-    <div v-if="!node.isLeaf" class="arrow" />
+    <div
+      v-if="!node.isLeaf"
+      class="arrow"
+      :style="{
+        ...(theme.arrowColor && { borderColor: theme.arrowColor })
+      }"
+    />
   </div>
 </template>
 
@@ -38,21 +56,9 @@ export default {
   name: "FinderItem",
   mixins: [FinderListDropZone],
   props: {
-    node: {
-      type: Object,
-      required: true
-    },
-    treeModel: {
-      type: Object,
-      required: true
-    },
     selectable: {
       type: Boolean,
       default: false
-    },
-    options: {
-      type: Object,
-      default: () => ({})
     }
   },
   computed: {

--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -1,4 +1,5 @@
 <script>
+import { get } from "lodash-es";
 import FinderItem from "./FinderItem";
 import FinderListDropZone from "./FinderListDropZone";
 
@@ -12,6 +13,7 @@ function renderItems(h, { props }) {
           node={props.parent}
           treeModel={props.treeModel}
           dragEnabled={props.dragEnabled}
+          options={props.options}
         />
       )
     ],
@@ -64,9 +66,15 @@ export default {
   },
   render(h, { props, listeners }) {
     const DropZoneComponent = props.dropZoneComponent;
+    const separatorColor = get(props, "options.theme.separatorColor", "");
+    const separatorWidth = get(props, "options.theme.separatorWidth", "");
+    const style = {
+      ...(separatorColor && { borderColor: separatorColor }),
+      ...(separatorWidth && { borderWidth: separatorWidth })
+    };
 
     return [
-      <div class="list">
+      <div class="list" style={style}>
         {[
           ...renderItems(h, { props, listeners }),
           ...[
@@ -76,6 +84,7 @@ export default {
                 treeModel={props.treeModel}
                 node={props.parent}
                 dragEnabled={props.dragEnabled}
+                options={props.options}
               />
             )
           ]

--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -2,6 +2,12 @@
   <div
     class="drop-zone"
     :class="{ 'drag-over': dragOver }"
+    :style="{
+      ...(dragOver &&
+        theme.primaryColor && { borderColor: theme.primaryColor }),
+      ...(dragOver &&
+        theme.dropZoneBgColor && { backgroundColor: theme.dropZoneBgColor })
+    }"
     @dragenter.prevent="onDragEnter"
     @dragleave.prevent="onDragLeave"
     @dragover.prevent
@@ -10,6 +16,8 @@
 </template>
 
 <script>
+import { get } from "lodash-es";
+
 export default {
   name: "FinderListDropZone",
   props: {
@@ -24,6 +32,10 @@ export default {
     dragEnabled: {
       type: Boolean,
       default: false
+    },
+    options: {
+      type: Object,
+      default: () => ({})
     }
   },
   data: () => ({
@@ -32,6 +44,9 @@ export default {
   computed: {
     dragOver() {
       return this.dragCounter > 0;
+    },
+    theme() {
+      return get(this, "options.theme", {});
     }
   },
   methods: {

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -131,6 +131,23 @@ describe("Finder", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("should match snapshot with custom theme", () => {
+    const wrapper = mount(Finder, {
+      propsData: {
+        tree,
+        theme: {
+          primaryColor: "#41b883",
+          arrowColor: "#555",
+          separatorColor: "#eee",
+          separatorWidth: "3px",
+          dropZoneBgColor: "rgba(112, 195, 112, 0.3)",
+          draggedItemBgColor: "rgba(112, 195, 112, 0.6)"
+        }
+      }
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+
   describe("Selection", () => {
     it("should match snapshot", () => {
       const wrapper = mount(Finder, {

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -106,6 +106,25 @@ exports[`Finder should match snapshot with an updated tree 1`] = `
 </div>
 `;
 
+exports[`Finder should match snapshot with custom theme 1`] = `
+<div class="tree-container">
+  <div class="list-container">
+    <div class="list" style="border-color: #eee; border-width: 3px;">
+      <div draggable="false" class="item">
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 11</div>
+        <div class="arrow" style="border-color: #555;"></div>
+      </div>
+      <div draggable="false" class="item">
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 12</div>
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Finder should match snapshot with expanded item and emit event 1`] = `
 <div class="tree-container">
   <div class="list-container">

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -152,4 +152,23 @@ storiesOf("Finder", module)
           '<div style="color: blue"><em>Name:</em> <strong>{{ item.label }}</strong></div>'
       };
     }
+  }))
+  .add("Custom theme", () => ({
+    mixins: [filterMixin],
+    computed: {
+      theme() {
+        return {
+          primaryColor: "#41b883",
+          arrowColor: "#555",
+          separatorColor: "#eee",
+          separatorWidth: "3px",
+          dropZoneBgColor: "rgba(112, 195, 112, 0.3)",
+          draggedItemBgColor: "rgba(112, 195, 112, 0.6)"
+        };
+      }
+    },
+    template: `<Finder :tree="tree" :theme="theme" :selectable="true" :drag-enabled="true" style="height: 100%"></Finder>`,
+    created() {
+      this.tree = data;
+    }
   }));


### PR DESCRIPTION
Add a `theme` prop that allows to customize the look of the component:

```html
<Finder :tree="tree" :theme="theme" />
```

```js
// ...
data() {
  return {
    theme: {
      primaryColor: "#2196f3",
      arrowColor: "black",
      separatorColor: "#ccc",
      separatorWidth: "1px",
      dropZoneBgColor: "rgba(33, 150, 243, 0.2)",
      draggedItemBgColor: "rgba(33, 150, 243, 0.5)"
    }
  }
}
```

Here are the available properties:

| Name                 | Description                                                  |
| -------------------- | ------------------------------------------------------------ |
| `primaryColor`       | Primary color used for expanded items, dropzone borders...   |
| `arrowColor`         | Color of arrows in expandable items                          |
| `separatorColor`     | Border color of separators between lists                     |
| `separatorWidth`     | Width value of separators between lists                      |
| `dropZoneBgColor`    | Background color of drop zones (visible when Drag & Drop)    |
| `draggedItemBgColor` | Background color of dragged items (visible when Drag & Drop) |