### PR TITLE
build(package): include CSS in dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "jsdelivr": "dist/vue-finder.js",
   "files": [
     "src",
-    "dist/*.js"
+    "dist/*"
   ],
   "author": "Jérémie Ledentu <jledentu@gmail.com>",
   "repository": {


### PR DESCRIPTION
Fix dist files (include all the files located in `dist`, especially `vue-finder.css`)