### PR TITLE
feat(default-expanded): add defaultExpanded prop

### DIFF
--- a/docs/.vuepress/components/FinderExample.vue
+++ b/docs/.vuepress/components/FinderExample.vue
@@ -9,7 +9,13 @@ export default {
   components: {
     Finder
   },
-  props: ["selectable", "filter", "dragEnabled", "useCustomItemComponent"],
+  props: [
+    "selectable",
+    "filter",
+    "dragEnabled",
+    "useCustomItemComponent",
+    "defaultExpanded"
+  ],
   data() {
     return {
       tree: {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,7 +28,7 @@ const tree = {
 };
 ```
 
-<FinderExample></FinderExample>
+<FinderExample defaultExpanded="grape"></FinderExample>
 
 ## Selection
 

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -94,6 +94,13 @@ export default {
       default: undefined
     },
     /**
+     * ID of the item expanded when loaded.
+     */
+    defaultExpanded: {
+      type: String,
+      default: undefined
+    },
+    /**
      * Custom component to render items.
      */
     itemComponent: {
@@ -149,7 +156,10 @@ export default {
     });
   },
   created() {
-    this.treeModel = new TreeModel(this.tree, this.filter);
+    this.treeModel = new TreeModel(this.tree, {
+      filter: this.filter,
+      defaultExpanded: this.defaultExpanded
+    });
 
     this.treeModel.on("expand", expanded => {
       this.$nextTick(() => {

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -112,6 +112,17 @@ describe("Finder", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("should match snapshot with default expanded", () => {
+    const wrapper = mount(Finder, {
+      propsData: {
+        tree,
+        defaultExpanded: "test112"
+      }
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("should match snapshot with an updated tree", () => {
     const wrapper = mount(Finder, {
       propsData: {

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -125,6 +125,39 @@ exports[`Finder should match snapshot with custom theme 1`] = `
 </div>
 `;
 
+exports[`Finder should match snapshot with default expanded 1`] = `
+<div class="tree-container">
+  <div class="list-container">
+    <div class="list">
+      <div draggable="false" class="item expanded">
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 11</div>
+        <div class="arrow"></div>
+      </div>
+      <div draggable="false" class="item">
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 12</div>
+        <!---->
+      </div>
+    </div>
+    <div class="list-container">
+      <div class="list">
+        <div draggable="false" class="item">
+          <!---->
+          <div item="[object Object]" class="inner-item">Test 111</div>
+          <!---->
+        </div>
+        <div draggable="false" class="item expanded">
+          <!---->
+          <div item="[object Object]" class="inner-item">Test 112</div>
+          <!---->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Finder should match snapshot with expanded item and emit event 1`] = `
 <div class="tree-container">
   <div class="list-container">

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -8,7 +8,7 @@ import {
 import EventManager from "./event-manager";
 
 export default class extends EventManager {
-  constructor(root = {}, filter) {
+  constructor(root = {}, options = {}) {
     super();
     Object.defineProperty(this, "_root", {
       value: root,
@@ -21,23 +21,25 @@ export default class extends EventManager {
       writable: true
     });
 
-    this._initExpanded();
+    this._initExpanded(options.defaultExpanded);
 
     this.selected = Object.values(this.nodesMap)
       .filter(({ selected }) => selected)
       .map(({ id }) => id);
 
     this.filtered = [];
-    if (filter) {
-      this.filter = filter;
+    if (options.filter) {
+      this.filter = options.filter;
     }
 
     this._updateVisibleTree();
     this.draggedNodeId = undefined;
   }
 
-  _initExpanded() {
-    if (this.root && this.root.id) {
+  _initExpanded(defaultExpanded) {
+    if (defaultExpanded) {
+      this.expandNode(defaultExpanded);
+    } else if (this.root && this.root.id) {
       this.expanded = [this.root.id];
       this.expandedWithoutFilter = this.expanded;
     } else {


### PR DESCRIPTION
Add a `defaultExpanded` prop that allows to define the ID of the item expanded by default when the finder is loaded.