### PR TITLE
fix(prop-validation): fix type of itemComponent prop

### DIFF
--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -104,7 +104,7 @@ export default {
      * Custom component to render items.
      */
     itemComponent: {
-      type: Function,
+      type: [String, Object],
       default: undefined
     },
     /**


### PR DESCRIPTION
The `type` of the `itemComponent` is wrong, causing such warnings:

> `[Vue warn]: Invalid prop: type check failed for prop "itemComponent". Expected Function, got Object `

 This PR replaces the type `Function` by `String` or `Object`.