### PR TITLE
fix(drag-n-drop): prevent opening link on drop in Firefox

### DIFF
--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -60,7 +60,8 @@ export default {
         this.dragCounter--;
       }
     },
-    onDrop() {
+    onDrop(event) {
+      event.preventDefault();
       if (!this.treeModel.isDragging()) {
         return;
       }


### PR DESCRIPTION
In Firefox, a URL is opened when dropping an item on another. This MR fixes that by calling `event.preventDefault()`.