### PR TITLE
feat(drag-drop): handle canDrop and drag handles

### DIFF
--- a/docs/.vuepress/components/FinderExample.vue
+++ b/docs/.vuepress/components/FinderExample.vue
@@ -13,6 +13,7 @@ export default {
     "selectable",
     "filter",
     "dragEnabled",
+    "hasDragHandle",
     "useCustomItemComponent",
     "defaultExpanded"
   ],

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -75,3 +75,7 @@ You can enable the drag and drop of items with `dragEnabled`:
 ```
 
 <FinderExample :dragEnabled="true"></FinderExample>
+
+You can show handles to drag items with `hasDragHandle`:
+
+<FinderExample :dragEnabled="true" :has-drag-handle="true"></FinderExample>

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -22,7 +22,9 @@ function renderTree(h, context, item) {
   const options = {
     sortBy: context.sortBy,
     itemComponent: context.itemComponent,
-    theme: context.theme
+    theme: context.theme,
+    hasDragHandle: context.hasDragHandle,
+    canDrop: context.canDrop
   };
 
   const itemList = (
@@ -78,6 +80,24 @@ export default {
     dragEnabled: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Whether a drag handle is displayed to drag items.
+     */
+    hasDragHandle: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Function that indicates if a dragged item can be dropped on another.
+     *
+     * @param {string} target ID of the drop target
+     * @param {string} source ID of the dragged item
+     * @return Should return `true` if `source` can be dropped on `target`
+     */
+    canDrop: {
+      type: Function,
+      default: undefined
     },
     /**
      * Function to filter displayed items.

--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -1,7 +1,10 @@
 <template>
   <div
     class="drop-zone"
-    :class="{ 'drag-over': dragOver }"
+    :class="{
+      'drag-over': dragOver,
+      'no-drop': treeModel.isDragging() && !canDrop
+    }"
     :style="{
       ...(dragOver &&
         theme.primaryColor && { borderColor: theme.primaryColor }),
@@ -47,22 +50,28 @@ export default {
     },
     theme() {
       return get(this, "options.theme", {});
+    },
+    canDrop() {
+      return (
+        !this.options.canDrop ||
+        this.options.canDrop(this.node.id, this.treeModel.draggedNodeId)
+      );
     }
   },
   methods: {
     onDragEnter() {
-      if (this.treeModel.isDragging()) {
+      if (this.canDrop && this.treeModel.isDragging()) {
         this.dragCounter++;
       }
     },
     onDragLeave() {
-      if (this.treeModel.isDragging()) {
+      if (this.canDrop && this.treeModel.isDragging()) {
         this.dragCounter--;
       }
     },
     onDrop(event) {
       event.preventDefault();
-      if (!this.treeModel.isDragging()) {
+      if (!this.canDrop || !this.treeModel.isDragging()) {
         return;
       }
       this.dragCounter = 0;
@@ -87,5 +96,9 @@ export default {
     border: dashed 3px $primaryColor;
     background-color: change-color($primaryColor, $alpha: 0.2);
   }
+}
+
+.no-drop * {
+  cursor: no-drop;
 }
 </style>

--- a/src/components/__tests__/FinderItem.test.js
+++ b/src/components/__tests__/FinderItem.test.js
@@ -155,6 +155,7 @@ describe("FinderItem", () => {
 
     describe("dragover", () => {
       it("should call treeModel.expandNode", () => {
+        const dataTransfer = {};
         const wrapper = mount(FinderItem, {
           propsData: {
             treeModel,
@@ -163,7 +164,49 @@ describe("FinderItem", () => {
           }
         });
 
-        wrapper.trigger("dragover");
+        wrapper.trigger("dragover", {
+          dataTransfer
+        });
+        expect(dataTransfer.dropEffect).toBe("all");
+        expect(treeModel.expandNode).toHaveBeenCalledWith("test111");
+      });
+
+      it("should set dataTransfer.dropEffect = `all` if can drop", () => {
+        const dataTransfer = {};
+        const wrapper = mount(FinderItem, {
+          propsData: {
+            treeModel,
+            node,
+            dragEnabled: true,
+            options: {
+              canDrop: () => true
+            }
+          }
+        });
+
+        wrapper.trigger("dragover", {
+          dataTransfer
+        });
+        expect(dataTransfer.dropEffect).toBe("all");
+      });
+
+      it("should set dataTransfer.dropEffect = `none` if can not drop", () => {
+        const dataTransfer = {};
+        const wrapper = mount(FinderItem, {
+          propsData: {
+            treeModel,
+            node,
+            dragEnabled: true,
+            options: {
+              canDrop: () => false
+            }
+          }
+        });
+
+        wrapper.trigger("dragover", {
+          dataTransfer
+        });
+        expect(dataTransfer.dropEffect).toBe("none");
         expect(treeModel.expandNode).toHaveBeenCalledWith("test111");
       });
 
@@ -206,6 +249,25 @@ describe("FinderItem", () => {
 
         wrapper.trigger("dragend");
         expect(treeModel.stopDrag).not.toHaveBeenCalled();
+      });
+
+      it("should set `draggable = false` if `options.hasDragHandle` is true", () => {
+        const wrapper = mount(FinderItem, {
+          propsData: {
+            treeModel,
+            node,
+            dragEnabled: true,
+            options: {
+              hasDragHandle: true
+            }
+          }
+        });
+
+        wrapper.find(".drag-handle").trigger("mousedown");
+        expect(wrapper.vm.draggable).toBe(true);
+
+        wrapper.trigger("dragend");
+        expect(wrapper.vm.draggable).toBe(false);
       });
     });
   });

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -4,11 +4,13 @@ exports[`Finder API #expand should expand the given item and emit the \`expand\`
 <div class="tree-container">
   <div class="list-container">
     <div class="list">
-      <div draggable="false" class="item expanded"><input type="checkbox">
+      <div draggable="false" class="item expanded">
+        <!----> <input type="checkbox">
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
-      <div draggable="false" class="item"><input type="checkbox">
+      <div draggable="false" class="item">
+        <!----> <input type="checkbox">
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
@@ -24,11 +26,13 @@ exports[`Finder Drag & Drop should match snapshot 1`] = `
       <div class="drop-zone"></div>
       <div draggable="true" class="item draggable">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
       <div class="drop-zone"></div>
       <div draggable="true" class="item draggable">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -43,11 +47,13 @@ exports[`Finder Selection should match snapshot 1`] = `
 <div class="tree-container">
   <div class="list-container">
     <div class="list">
-      <div draggable="false" class="item"><input type="checkbox">
+      <div draggable="false" class="item">
+        <!----> <input type="checkbox">
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
-      <div draggable="false" class="item"><input type="checkbox">
+      <div draggable="false" class="item">
+        <!----> <input type="checkbox">
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
@@ -62,10 +68,12 @@ exports[`Finder should match snapshot 1`] = `
     <div class="list">
       <div draggable="false" class="item">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -80,10 +88,12 @@ exports[`Finder should match snapshot with a custom item component 1`] = `
   <div class="list-container">
     <div class="list">
       <div draggable="false" class="item">
+        <!---->
         <!----> <span item="[object Object]" class="inner-item">Test 11</span>
         <div class="arrow"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!----> <span item="[object Object]" class="inner-item">Test 12</span>
         <!---->
       </div>
@@ -97,6 +107,7 @@ exports[`Finder should match snapshot with an updated tree 1`] = `
   <div class="list-container">
     <div class="list">
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 31</div>
         <div class="arrow"></div>
@@ -112,10 +123,12 @@ exports[`Finder should match snapshot with custom theme 1`] = `
     <div class="list" style="border-color: #eee; border-width: 3px;">
       <div draggable="false" class="item">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow" style="border-color: #555;"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -131,10 +144,12 @@ exports[`Finder should match snapshot with default expanded 1`] = `
     <div class="list">
       <div draggable="false" class="item expanded">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -144,10 +159,12 @@ exports[`Finder should match snapshot with default expanded 1`] = `
       <div class="list">
         <div draggable="false" class="item">
           <!---->
+          <!---->
           <div item="[object Object]" class="inner-item">Test 111</div>
           <!---->
         </div>
         <div draggable="false" class="item expanded">
+          <!---->
           <!---->
           <div item="[object Object]" class="inner-item">Test 112</div>
           <!---->
@@ -164,10 +181,12 @@ exports[`Finder should match snapshot with expanded item and emit event 1`] = `
     <div class="list">
       <div draggable="false" class="item expanded">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -183,6 +202,7 @@ exports[`Finder should match snapshot with filter 1`] = `
     <div class="list">
       <div draggable="false" class="item">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
@@ -197,10 +217,12 @@ exports[`Finder should match snapshot with initial filter 1`] = `
     <div class="list">
       <div draggable="false" class="item">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
@@ -218,10 +240,12 @@ exports[`Finder should match snapshot with sort 1`] = `
     <div class="list">
       <div draggable="false" class="item">
         <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
       <div draggable="false" class="item">
+        <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>

--- a/src/components/__tests__/__snapshots__/FinderItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FinderItem.test.js.snap
@@ -3,6 +3,7 @@
 exports[`FinderItem Drag & drop should match snapshot if dragEnabled is \`true\` 1`] = `
 <div draggable="true" class="item draggable">
   <!---->
+  <!---->
   <div item="[object Object]" class="inner-item"></div>
   <div class="arrow"></div>
 </div>
@@ -11,13 +12,15 @@ exports[`FinderItem Drag & drop should match snapshot if dragEnabled is \`true\`
 exports[`FinderItem Expand should match snapshot if expanded 1`] = `
 <div draggable="false" class="item expanded">
   <!---->
+  <!---->
   <div item="[object Object]" class="inner-item"></div>
   <div class="arrow"></div>
 </div>
 `;
 
 exports[`FinderItem Selection should match snapshot if selectable 1`] = `
-<div draggable="false" class="item"><input type="checkbox">
+<div draggable="false" class="item">
+  <!----> <input type="checkbox">
   <div item="[object Object]" class="inner-item"></div>
   <div class="arrow"></div>
 </div>
@@ -25,6 +28,7 @@ exports[`FinderItem Selection should match snapshot if selectable 1`] = `
 
 exports[`FinderItem should match snapshot 1`] = `
 <div draggable="false" class="item">
+  <!---->
   <!---->
   <div item="[object Object]" class="inner-item"></div>
   <div class="arrow"></div>

--- a/src/components/__tests__/__snapshots__/FinderList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FinderList.test.js.snap
@@ -4,10 +4,12 @@ exports[`FinderList should match snapshot 1`] = `
 <div class="list">
   <div draggable="false" class="item">
     <!---->
+    <!---->
     <div item="[object Object]" class="inner-item">Test 11</div>
     <div class="arrow"></div>
   </div>
   <div draggable="false" class="item">
+    <!---->
     <!---->
     <div item="[object Object]" class="inner-item">Test 12</div>
     <!---->
@@ -20,11 +22,13 @@ exports[`FinderList should match snapshot if \`dragEnabled\` is true 1`] = `
   <div class="drop-zone"></div>
   <div draggable="true" class="item draggable">
     <!---->
+    <!---->
     <div item="[object Object]" class="inner-item">Test 11</div>
     <div class="arrow"></div>
   </div>
   <div class="drop-zone"></div>
   <div draggable="true" class="item draggable">
+    <!---->
     <!---->
     <div item="[object Object]" class="inner-item">Test 12</div>
     <!---->
@@ -35,11 +39,13 @@ exports[`FinderList should match snapshot if \`dragEnabled\` is true 1`] = `
 
 exports[`FinderList should match snapshot if \`selectable\` is true 1`] = `
 <div class="list">
-  <div draggable="false" class="item"><input type="checkbox">
+  <div draggable="false" class="item">
+    <!----> <input type="checkbox">
     <div item="[object Object]" class="inner-item">Test 11</div>
     <div class="arrow"></div>
   </div>
-  <div draggable="false" class="item"><input type="checkbox">
+  <div draggable="false" class="item">
+    <!----> <input type="checkbox">
     <div item="[object Object]" class="inner-item">Test 12</div>
     <!---->
   </div>

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/vue";
-import { withKnobs, text } from "@storybook/addon-knobs";
+import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 
 const MAX_DEPTH = 4;
 const CHILDREN_NUMBER = 10;
@@ -141,10 +141,19 @@ storiesOf("Finder", module)
     }
   }))
   .add("Drag and drop", () => ({
+    props: {
+      hasDragHandle: {
+        type: Boolean,
+        default: boolean("Show drag handle", false)
+      }
+    },
     mixins: [filterMixin],
-    template: `<Finder :tree="tree" :drag-enabled="true" style="height: 100%"></Finder>`,
+    template: `<Finder :tree="tree" :drag-enabled="true" :can-drop="canDrop" :has-drag-handle="hasDragHandle" style="height: 100%"></Finder>`,
     created() {
       this.tree = data;
+      this.canDrop = target => {
+        return target !== "tomato";
+      };
     }
   }))
   .add("Custom item component", () => ({


### PR DESCRIPTION
This PR adds some options to the drag & drop feature:

* `hasDragHandle`: displays handles to drag items
* `canDrop`:  function that indicates if a dragged item can be dropped on another