### PR TITLE
Custom drag image component

### DIFF
--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -22,6 +22,7 @@ function renderTree(h, context, item) {
   const options = {
     sortBy: context.sortBy,
     itemComponent: context.itemComponent,
+    dragImageComponent: context.dragImageComponent,
     theme: context.theme,
     hasDragHandle: context.hasDragHandle,
     canDrop: context.canDrop
@@ -125,6 +126,13 @@ export default {
      * Custom component to render items.
      */
     itemComponent: {
+      type: [String, Object],
+      default: undefined
+    },
+    /**
+     * Custom component to render drag image.
+     */
+    dragImageComponent: {
       type: [String, Object],
       default: undefined
     },

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -162,6 +162,7 @@ export default {
     onDragEnd() {
       if (this.ghost) {
         this.ghost.parentNode.removeChild(this.ghost);
+        this.ghost = null;
       }
       if (!this.dragEnabled) {
         return;

--- a/src/utils/dom-utils.js
+++ b/src/utils/dom-utils.js
@@ -1,0 +1,5 @@
+export function css(element, properties) {
+  Object.entries(properties).forEach(([prop, value]) => {
+    element.style[prop] = value;
+  });
+}

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -156,6 +156,19 @@ storiesOf("Finder", module)
       };
     }
   }))
+  .add("Custom drag image component", () => ({
+    mixins: [filterMixin],
+    template: `<Finder :tree="tree" :drag-enabled="true" :drag-image-component="dragImageComponent" style="height: 100%"></Finder>`,
+    created() {
+      this.tree = data;
+      this.dragImageComponent = {
+        props: ["item"],
+        template: `<div style="background-color: white; display: flex; align-items: center; padding: 10px; border: solid 1px #ddd">
+            Dragging {{ item.label }}
+          </div>`
+      };
+    }
+  }))
   .add("Custom item component", () => ({
     mixins: [filterMixin],
     template: `<Finder :tree="tree" :item-component="itemComponent" :selectable="true" :drag-enabled="true" style="height: 100%"></Finder>`,


### PR DESCRIPTION
This MR adds a `dragImageComponent` prop that allows to customize the drag image (ghost displayed when an item is dragged).