### PR TITLE
feat(move): add index in moved event

### DIFF
--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -295,16 +295,17 @@ export default {
         selected
       });
     });
-    this.treeModel.on("move", ({ moved, to }) => {
+    this.treeModel.on("move", ({ moved, to, index }) => {
       /**
        * This event is triggered when an item has been moved by drag and drop.
+       * When an item is dropped on a dropzone between two elements, a `index` is also provided.
        *
        * ```html
        * <Finder :tree="tree" @move="onMove"/>
        * ```
        *
        * ```js
-       * onMove({ moved, to }) {
+       * onMove({ moved, to, index }) {
        *   console.log(
        *     `Item with ${moved} ID has been moved
        *     to its new parent with ${to} ID`
@@ -316,10 +317,12 @@ export default {
        * @type {object}
        * @property {string} moved ID of the moved item
        * @property {string} to    ID of the parent on which the item has been moved to
+       * @property {number} index Index of the dropzone
        */
       this.$emit("move", {
         moved,
-        to
+        to,
+        index
       });
     });
   },

--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -18,6 +18,7 @@ function renderItems(h, { props, expandedItemIndex }) {
           node={props.parent}
           treeModel={props.treeModel}
           dragEnabled={props.dragEnabled}
+          index={index}
           options={props.options}
         />
       )
@@ -129,6 +130,7 @@ export default {
                 treeModel={props.treeModel}
                 node={props.parent}
                 dragEnabled={props.dragEnabled}
+                index={props.items.length}
                 options={props.options}
               />
             )

--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -45,6 +45,10 @@ export default {
       type: Boolean,
       default: false
     },
+    index: {
+      type: Number,
+      default: undefined
+    },
     options: {
       type: Object,
       default: () => ({})
@@ -88,7 +92,7 @@ export default {
         return;
       }
       this.dragCounter = 0;
-      this.treeModel.dropOnNode(this.node.id);
+      this.treeModel.dropOnNode(this.node.id, this.index);
     }
   }
 };

--- a/src/components/__tests__/FinderListDropZone.test.js
+++ b/src/components/__tests__/FinderListDropZone.test.js
@@ -107,7 +107,21 @@ describe("FinderListDropZone", () => {
         }
       });
       wrapper.trigger("drop");
-      expect(treeModel.dropOnNode).toHaveBeenCalledWith("test111");
+      expect(treeModel.dropOnNode).toHaveBeenCalledWith("test111", undefined);
+    });
+
+    it("should call `treeModel.dropOnNode` with index", () => {
+      treeModel.isDragging.mockReturnValue(true);
+      const wrapper = mount(FinderListDropZone, {
+        propsData: {
+          treeModel,
+          node,
+          dragEnabled: true,
+          index: 5
+        }
+      });
+      wrapper.trigger("drop");
+      expect(treeModel.dropOnNode).toHaveBeenCalledWith("test111", 5);
     });
 
     it("should not call `treeModel.dropOnNode` if not dragging", () => {

--- a/src/utils/__tests__/tree-model.test.js
+++ b/src/utils/__tests__/tree-model.test.js
@@ -348,7 +348,54 @@ describe("TreeModel", () => {
           "test112",
           "test12"
         ]);
-        expect(onMove).toHaveBeenCalled();
+        expect(onMove).toHaveBeenCalledWith({
+          moved: "test12",
+          to: "test112",
+          index: undefined
+        });
+      });
+
+      it("should move the dragged node at a given index", () => {
+        model.startDrag("test12");
+        model.dropOnNode("test11", 1);
+        expect(model.visibleTree).toEqual({
+          id: "test1",
+          children: [
+            {
+              id: "test11",
+              selected: true,
+              children: [
+                {
+                  id: "test111",
+                  children: [],
+                  isLeaf: true,
+                  parent: "test11"
+                },
+                {
+                  id: "test12",
+                  children: [],
+                  isLeaf: true,
+                  parent: "test11"
+                },
+                {
+                  id: "test112",
+                  children: [],
+                  isLeaf: true,
+                  parent: "test11"
+                }
+              ],
+              isLeaf: false,
+              parent: "test1"
+            }
+          ],
+          isLeaf: false
+        });
+        expect(onExpand).toHaveBeenCalledWith(["test1", "test11", "test12"]);
+        expect(onMove).toHaveBeenCalledWith({
+          moved: "test12",
+          to: "test11",
+          index: 1
+        });
       });
     });
   });

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -171,7 +171,7 @@ storiesOf("Finder", module)
   }))
   .add("Custom item component", () => ({
     mixins: [filterMixin],
-    template: `<Finder :tree="tree" :item-component="itemComponent" :selectable="true" :drag-enabled="true" style="height: 100%"></Finder>`,
+    template: `<Finder :tree="tree" :item-component="itemComponent" :selectable="true" :drag-enabled="true" :has-drag-handle="true" style="height: 100%"></Finder>`,
     created() {
       this.tree = data;
       this.itemComponent = {


### PR DESCRIPTION
This PR adds a `index` property in the `move` event. It is the index of the dropzone where the item is dragged. When dragged on an item, the index is `undefined` (the element is pushed at the end of the children). 

Closes #79 