### PR TITLE
fix(drag): fix drag handle in Firefox

### DIFF
--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -4,7 +4,7 @@
     role="button"
     :class="{
       expanded,
-      draggable: dragEnabled && draggable,
+      draggable: dragEnabled && !options.hasDragHandle,
       dragged,
       'has-drag-handle': dragEnabled && options.hasDragHandle,
       'drag-over': dragOver,
@@ -26,7 +26,7 @@
       ...(dragOver &&
         theme.dropZoneBgColor && { backgroundColor: theme.dropZoneBgColor })
     }"
-    :draggable="dragEnabled && draggable"
+    :draggable="dragEnabled && !options.hasDragHandle"
     :aria-expanded="node.isLeaf ? undefined : expanded"
     @dragenter="onDragEnter"
     @dragleave="onDragLeave"
@@ -39,8 +39,8 @@
     <div
       v-if="dragEnabled && options.hasDragHandle"
       class="drag-handle"
-      @mousedown="draggable = true"
-      @mouseup="draggable = false"
+      @mousedown="$el.setAttribute('draggable', 'true')"
+      @mouseup="$el.setAttribute('draggable', 'false')"
     >
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
         <path
@@ -84,11 +84,6 @@ export default {
       default: false
     }
   },
-  data() {
-    return {
-      draggable: false
-    };
-  },
   computed: {
     expanded() {
       return this.treeModel.isNodeExpanded(this.node.id);
@@ -104,12 +99,6 @@ export default {
     }
   },
   watch: {
-    "options.hasDragHandle": {
-      immediate: true,
-      handler(newValue) {
-        this.draggable = !newValue;
-      }
-    },
     dragOver(newValue) {
       if (newValue && this.canDrop && !this.node.isLeaf) {
         this.dragOverTimeout = setTimeout(
@@ -171,7 +160,7 @@ export default {
       }
 
       if (this.options.hasDragHandle) {
-        this.draggable = false;
+        this.$el.setAttribute("draggable", "false");
       }
 
       this.treeModel.stopDrag();

--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -152,7 +152,7 @@ export default {
   overflow: auto;
   flex-shrink: 0;
 
-  .draggable {
+  [draggable="true"] {
     cursor: move;
     cursor: grab;
   }

--- a/src/components/__tests__/FinderItem.test.js
+++ b/src/components/__tests__/FinderItem.test.js
@@ -391,10 +391,10 @@ describe("FinderItem", () => {
         });
 
         wrapper.find(".drag-handle").trigger("mousedown");
-        expect(wrapper.vm.draggable).toBe(true);
+        expect(wrapper.vm.$el.getAttribute("draggable")).toBe("true");
 
         wrapper.trigger("dragend");
-        expect(wrapper.vm.draggable).toBe(false);
+        expect(wrapper.vm.$el.getAttribute("draggable")).toBe("false");
       });
 
       it("should remove ghost element if `dragImageComponent` is defined", () => {


### PR DESCRIPTION
In Firefox, the click on the drag handle sometimes doesn't trigger the dragstart. I guess it's because the component is re-rendered.