### PR TITLE
fix(expand): correctly restore expanded after tree update

### DIFF
--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -196,10 +196,7 @@ export default class extends EventManager {
     this._root = newRoot;
     this.nodesMap = buildNodesMap(newRoot);
 
-    if (
-      !this.expanded.length ||
-      this.expanded.some(({ id }) => !this.nodesMap[id])
-    ) {
+    if (!this.expanded.length || this.expanded.some(id => !this.nodesMap[id])) {
       // Initialize the expanded since not compatible with the new tree
       this._initExpanded();
     }


### PR DESCRIPTION
This PR allows to keep the expanded path when `tree` prop is updated.