### PR TITLE
feat(customization): add cssClass option

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -2,6 +2,40 @@
 
 Vue Finder provides some options to customize its look.
 
+## CSS classes
+
+You can pass CSS classes to each item component by setting `cssClass`:
+
+```html
+<Finder :tree="tree" />
+```
+
+```js
+const tree = {
+  id: "root",
+  children: [
+    {
+      id: "fruits",
+      label: "Fruits",
+      cssClass: "my-item fruits",
+      children: [
+        { id: "apple", label: "Apple" }
+        // ...
+      ]
+    },
+    {
+      id: "vegetables",
+      label: "Vegetables",
+      cssClass: "my-item vegetables",
+      children: [
+        { id: "bean", label: "Beans" }
+        // ...
+      ]
+    }
+  ]
+};
+```
+
 ## Theming
 
 The `Finder` component accepts a `theme` prop that allows to customize some CSS properties:

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -2,14 +2,17 @@
   <div
     class="item"
     role="button"
-    :class="{
-      expanded,
-      draggable: dragEnabled && !options.hasDragHandle,
-      dragged,
-      'has-drag-handle': dragEnabled && options.hasDragHandle,
-      'drag-over': dragOver,
-      'no-drop': treeModel.isDragging() && !canDrop
-    }"
+    :class="[
+      node.cssClass || '',
+      {
+        expanded,
+        draggable: dragEnabled && !options.hasDragHandle,
+        dragged,
+        'has-drag-handle': dragEnabled && options.hasDragHandle,
+        'drag-over': dragOver,
+        'no-drop': treeModel.isDragging() && !canDrop
+      }
+    ]"
     :style="{
       ...(expanded &&
         theme.primaryColor && { backgroundColor: theme.primaryColor }),

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -16,7 +16,8 @@ describe("Finder", () => {
           },
           {
             id: "test112",
-            label: "Test 112"
+            label: "Test 112",
+            cssClass: "custom-class"
           }
         ]
       },

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -22,7 +22,7 @@ exports[`Finder API #expand should expand the given item and emit the \`expand\`
           <div item="[object Object]" class="inner-item">Test 111</div>
           <!---->
         </div>
-        <div role="button" draggable="false" class="item expanded" tabindex="0">
+        <div role="button" draggable="false" class="item custom-class expanded" tabindex="0">
           <!----> <input type="checkbox" aria-label="Test 112">
           <div item="[object Object]" expanded="true" class="inner-item">Test 112</div>
           <!---->
@@ -183,7 +183,7 @@ exports[`Finder should match snapshot with default expanded 1`] = `
           <div item="[object Object]" class="inner-item">Test 111</div>
           <!---->
         </div>
-        <div role="button" draggable="false" class="item expanded" tabindex="0">
+        <div role="button" draggable="false" class="item custom-class expanded" tabindex="0">
           <!---->
           <!---->
           <div item="[object Object]" expanded="true" class="inner-item">Test 112</div>
@@ -220,7 +220,7 @@ exports[`Finder should match snapshot with expanded item and emit event 1`] = `
           <div item="[object Object]" class="inner-item">Test 111</div>
           <!---->
         </div>
-        <div role="button" draggable="false" class="item" tabindex="-1">
+        <div role="button" draggable="false" class="item custom-class" tabindex="-1">
           <!---->
           <!---->
           <div item="[object Object]" class="inner-item">Test 112</div>


### PR DESCRIPTION
Handle a `cssClass` option in item data, that allows to set custom CSS classes on item elements.