### PR TITLE
fix(filter): refresh filtered items on tree change

### DIFF
--- a/src/utils/__tests__/tree-model.test.js
+++ b/src/utils/__tests__/tree-model.test.js
@@ -179,6 +179,53 @@ describe("TreeModel", () => {
         isLeaf: false
       });
     });
+
+    it("should update the visible tree if root is changed", () => {
+      model.filter = ({ id }) => id.includes("test11");
+      model.root = {
+        id: "test1",
+        children: [
+          {
+            id: "test11",
+            selected: true,
+            children: [
+              {
+                id: "test111"
+              },
+              {
+                id: "test112"
+              },
+              {
+                id: "test113"
+              }
+            ]
+          },
+          {
+            id: "test12"
+          }
+        ]
+      };
+      expect(sortBy(model.filtered)).toEqual([
+        "test1",
+        "test11",
+        "test111",
+        "test112",
+        "test113"
+      ]);
+      expect(model.visibleTree).toEqual({
+        id: "test1",
+        children: [
+          {
+            id: "test11",
+            selected: true,
+            children: [],
+            isLeaf: false,
+            parent: "test1"
+          }
+        ],
+        isLeaf: false
+      });
+    });
   });
 
   describe("Drag & Drop", () => {

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -201,6 +201,7 @@ export default class extends EventManager {
       this._initExpanded();
     }
 
+    this._applyFilter();
     this._updateVisibleTree();
   }
 
@@ -212,6 +213,11 @@ export default class extends EventManager {
   set filter(newFilter) {
     this._filter = newFilter;
 
+    this._applyFilter();
+    this._updateVisibleTree();
+  }
+
+  _applyFilter() {
     if (!this._filter) {
       this.filtered = [];
     } else {
@@ -238,6 +244,5 @@ export default class extends EventManager {
         this.nodesMap
       );
     }
-    this._updateVisibleTree();
   }
 }


### PR DESCRIPTION
Recompute the filtered elements when `tree` is updated.