### PR TITLE
feat: item as title, parent item hide the check input if isnt selectable

### DIFF
--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -54,7 +54,7 @@
       </svg>
     </div>
     <input
-      v-if="selectable"
+      v-if="(selectable && !treeModel.hasChildren(node.id)) || node.selectable"
       type="checkbox"
       :checked="selected"
       :disabled="node.selectable === false"

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -209,7 +209,7 @@ describe("Finder", () => {
 
       wrapper
         .findAll(".item > input[type=checkbox]")
-        .at(1)
+        .at(0)
         .trigger("click");
       await wrapper.vm.$nextTick();
 

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -5,7 +5,8 @@ exports[`Finder API #expand should accept a \`sourceEvent\` argument 1`] = `
   <div class="list-container">
     <div class="list">
       <div role="button" draggable="false" class="item expanded" tabindex="0" aria-expanded="true">
-        <!----> <input type="checkbox" aria-label="Test 11">
+        <!---->
+        <!---->
         <div item="[object Object]" class="inner-item" expanded="true">Test 11</div>
         <div class="arrow"></div>
       </div>
@@ -38,7 +39,8 @@ exports[`Finder API #expand should expand the given item and emit the \`expand\`
   <div class="list-container">
     <div class="list">
       <div role="button" draggable="false" class="item expanded" tabindex="0" aria-expanded="true">
-        <!----> <input type="checkbox" aria-label="Test 11">
+        <!---->
+        <!---->
         <div item="[object Object]" class="inner-item" expanded="true">Test 11</div>
         <div class="arrow"></div>
       </div>
@@ -101,7 +103,8 @@ exports[`Finder Selection should match snapshot 1`] = `
   <div class="list-container">
     <div class="list">
       <div role="button" draggable="false" class="item" tabindex="0">
-        <!----> <input type="checkbox" aria-label="Test 11">
+        <!---->
+        <!---->
         <div item="[object Object]" class="inner-item">Test 11</div>
         <div class="arrow"></div>
       </div>

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -155,6 +155,12 @@ export default class extends EventManager {
     return !!parentNode && contains(parentNode, nodeId);
   }
 
+  hasChildren(nodeId) {
+    return this._getNode(nodeId).children
+      ? this._getNode(nodeId).children.length
+      : false;
+  }
+
   dropOnNode(nodeId, index) {
     if (!this.isDragging() || this.isNodeDragged(nodeId)) {
       return;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -62,7 +62,23 @@ const data = {
     {
       id: "vegetables",
       label: "Vegetables",
+      selectable: false,
       children: [
+        {
+          id: "chili",
+          label: "Chilli Peppers",
+          children: [
+            {
+              id: "chilli dutch red",
+              label: "Dutch red"
+            },
+            {
+              id: "chilli south american yellow",
+              label: "South American yellow",
+              selected: true
+            }
+          ]
+        },
         {
           id: "carrot",
           label: "Carrot",
@@ -85,6 +101,27 @@ const data = {
         {
           id: "bean",
           label: "Beans"
+        }
+      ]
+    },
+    {
+      id: "meat",
+      label: "Meats",
+      selectable: true,
+      children: [
+        {
+          id: "pork",
+          label: "Pork"
+        },
+        {
+          id: "seafood",
+          label: "Seafood",
+          selectable: false
+        },
+        {
+          id: "chicken",
+          label: "Chicken",
+          selected: true
         }
       ]
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/jledentu/vue-finder/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Hi, The reason why i made this change is because the "checkboxes" in parent items are something ugly and if is not selectionable, the "checkboxes" are only disabled, the parent item in many cases it will be like a title, and this feature makes it possible, the tests are ok and I increase the "Selectable Items Example" in the storybook, thanks a lot!. :D