### PR TITLE
feat(auto-select-children): add autoSelectDescendants and autoDeselectDescendants props

### DIFF
--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -110,6 +110,14 @@ export default {
       default: false
     },
     /**
+     * Whether all children should be recursively selected/unselected when their
+     * parent is respectively selected/unselected.
+     */
+    autoSelectChildren: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * Enable the drag & drop of items.
      */
     dragEnabled: {
@@ -238,6 +246,9 @@ export default {
     },
     filter(newFilter) {
       this.treeModel.filter = newFilter;
+    },
+    autoSelectChildren(newValue) {
+      this.treeModel.autoSelectChildren = newValue;
     }
   },
   beforeCreate() {

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -110,10 +110,16 @@ export default {
       default: false
     },
     /**
-     * Whether all children should be recursively selected/unselected when their
-     * parent is respectively selected/unselected.
+     * Whether all its descendants should be automatically selected when an item is selected.
      */
-    autoSelectChildren: {
+    autoSelectDescendants: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Whether all its descendants should be automatically deselected when an item is deselected.
+     */
+    autoDeselectDescendants: {
       type: Boolean,
       default: false
     },
@@ -247,8 +253,11 @@ export default {
     filter(newFilter) {
       this.treeModel.filter = newFilter;
     },
-    autoSelectChildren(newValue) {
-      this.treeModel.autoSelectChildren = newValue;
+    autoSelectDescendants(autoSelectDescendants) {
+      this.treeModel.autoSelectDescendants = autoSelectDescendants;
+    },
+    autoDeselectDescendants(autoDeselectDescendants) {
+      this.treeModel.autoDeselectDescendants = autoDeselectDescendants;
     }
   },
   beforeCreate() {
@@ -259,7 +268,9 @@ export default {
   created() {
     this.treeModel = new TreeModel(this.tree, {
       filter: this.filter,
-      defaultExpanded: this.defaultExpanded
+      defaultExpanded: this.defaultExpanded,
+      autoSelectDescendants: this.autoSelectDescendants,
+      autoDeselectDescendants: this.autoDeselectDescendants
     });
 
     this.treeModel.on("expand", (expanded, sourceEvent) => {

--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -24,6 +24,59 @@ describe("Finder", () => {
       {
         id: "test12",
         label: "Test 12"
+      },
+      {
+        id: "test13",
+        label: "Test 13",
+        children: [
+          {
+            id: "test131",
+            label: "Test 131",
+            children: [
+              {
+                id: "test1311",
+                label: "Test 1311"
+              },
+              {
+                id: "test1312",
+                label: "Test 1312"
+              }
+            ]
+          },
+          {
+            id: "test132",
+            label: "Test 132"
+          }
+        ]
+      },
+      {
+        id: "test14",
+        label: "Test 14",
+        selected: true,
+        children: [
+          {
+            id: "test141",
+            label: "Test 141",
+            selected: true,
+            children: [
+              {
+                id: "test1411",
+                label: "Test 1411",
+                selected: true
+              },
+              {
+                id: "test1412",
+                label: "Test 1412",
+                selected: true
+              }
+            ]
+          },
+          {
+            id: "test142",
+            label: "Test 142",
+            selected: true
+          }
+        ]
       }
     ]
   };
@@ -214,8 +267,74 @@ describe("Finder", () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted().select).toEqual([
-        [{ selected: ["test11", "test12"] }]
+        [
+          {
+            selected: [
+              "test11",
+              "test14",
+              "test141",
+              "test1411",
+              "test1412",
+              "test142",
+              "test12"
+            ]
+          }
+        ]
       ]);
+    });
+
+    it("should select descendants if `autoSelectDescendants` is true", async () => {
+      const wrapper = mount(Finder, {
+        propsData: {
+          tree,
+          selectable: true,
+          autoSelectDescendants: true
+        }
+      });
+
+      wrapper
+        .findAll(".item > input[type=checkbox]")
+        .at(2)
+        .trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted().select).toEqual([
+        [
+          {
+            selected: [
+              "test11",
+              "test14",
+              "test141",
+              "test1411",
+              "test1412",
+              "test142",
+              "test1311",
+              "test1312",
+              "test131",
+              "test132",
+              "test13"
+            ]
+          }
+        ]
+      ]);
+    });
+
+    it("should deselect descendants if `autoDeselectDescendants` is true", async () => {
+      const wrapper = mount(Finder, {
+        propsData: {
+          tree,
+          selectable: true,
+          autoDeselectDescendants: true
+        }
+      });
+
+      wrapper
+        .findAll(".item > input[type=checkbox]")
+        .at(3)
+        .trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted().select).toEqual([[{ selected: ["test11"] }]]);
     });
   });
 

--- a/src/components/__tests__/__snapshots__/Finder.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Finder.test.js.snap
@@ -14,6 +14,16 @@ exports[`Finder API #expand should accept a \`sourceEvent\` argument 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 13">
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 14">
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
     </div>
     <div class="list-container">
       <div class="list">
@@ -46,6 +56,16 @@ exports[`Finder API #expand should expand the given item and emit the \`expand\`
         <!----> <input type="checkbox" aria-label="Test 12">
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 13">
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 14">
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
       </div>
     </div>
     <div class="list-container">
@@ -88,6 +108,24 @@ exports[`Finder Drag & Drop should match snapshot 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div class="drop-zone">
+        <!---->
+      </div>
+      <div role="button" draggable="true" class="item draggable" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div class="drop-zone">
+        <!---->
+      </div>
+      <div role="button" draggable="true" class="item draggable" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
       <div class="drop-zone last">
         <!---->
       </div>
@@ -110,6 +148,16 @@ exports[`Finder Selection should match snapshot 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 13">
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!----> <input type="checkbox" aria-label="Test 14">
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
     </div>
   </div>
 </div>
@@ -131,6 +179,18 @@ exports[`Finder should match snapshot 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
     </div>
   </div>
 </div>
@@ -151,6 +211,16 @@ exports[`Finder should match snapshot with a custom arrow component 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div> <span theme="[object Object]" item="[object Object]"></span>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div> <span theme="[object Object]" item="[object Object]"></span>
+      </div>
     </div>
   </div>
 </div>
@@ -169,6 +239,16 @@ exports[`Finder should match snapshot with a custom item component 1`] = `
         <!---->
         <!----> <span item="[object Object]" class="inner-item">Test 12</span>
         <!---->
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!----> <span item="[object Object]" class="inner-item">Test 13</span>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!----> <span item="[object Object]" class="inner-item">Test 14</span>
+        <div class="arrow"></div>
       </div>
     </div>
   </div>
@@ -206,6 +286,18 @@ exports[`Finder should match snapshot with custom theme 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow" style="border-color: #555;"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow" style="border-color: #555;"></div>
+      </div>
     </div>
   </div>
 </div>
@@ -226,6 +318,18 @@ exports[`Finder should match snapshot with default expanded 1`] = `
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
       </div>
     </div>
     <div class="list-container">
@@ -263,6 +367,18 @@ exports[`Finder should match snapshot with expanded item and emit event 1`] = `
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
       </div>
     </div>
     <div class="list-container">
@@ -316,6 +432,18 @@ exports[`Finder should match snapshot with initial filter 1`] = `
         <div item="[object Object]" class="inner-item">Test 12</div>
         <!---->
       </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
     </div>
   </div>
 </div>
@@ -328,6 +456,18 @@ exports[`Finder should match snapshot with sort 1`] = `
   <div class="list-container">
     <div class="list">
       <div role="button" draggable="false" class="item" tabindex="0">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 14</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
+        <!---->
+        <!---->
+        <div item="[object Object]" class="inner-item">Test 13</div>
+        <div class="arrow"></div>
+      </div>
+      <div role="button" draggable="false" class="item" tabindex="-1">
         <!---->
         <!---->
         <div item="[object Object]" class="inner-item">Test 12</div>

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -128,7 +128,17 @@ export default class extends EventManager {
   }
 
   selectNode(nodeId, isSelected) {
-    this.selected = (isSelected ? union : difference)(this.selected, [nodeId]);
+    const nodeIdsToSelect = this.autoSelectChildren
+      ? getFilteredNodes(
+          node => node.selectable !== false,
+          nodeId,
+          this.nodesMap
+        )
+      : [nodeId];
+    this.selected = (isSelected ? union : difference)(
+      this.selected,
+      nodeIdsToSelect
+    );
     this.trigger("select", this.selected);
   }
 

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -32,6 +32,9 @@ export default class extends EventManager {
       this.filter = options.filter;
     }
 
+    this.autoSelectDescendants = options.autoSelectDescendants;
+    this.autoDeselectDescendants = options.autoDeselectDescendants;
+
     this._updateVisibleTree();
     this.draggedNodeId = undefined;
   }
@@ -128,7 +131,10 @@ export default class extends EventManager {
   }
 
   selectNode(nodeId, isSelected) {
-    const nodeIdsToSelect = this.autoSelectChildren
+    const changeChildren = isSelected
+      ? this.autoSelectDescendants
+      : this.autoDeselectDescendants;
+    const nodeIdsToSelect = changeChildren
       ? getFilteredNodes(
           node => node.selectable !== false,
           nodeId,

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -108,7 +108,10 @@ storiesOf("Finder", module)
         return item => RegExp(`^${filterString}.*`, "gi").test(item.label);
       }
     },
-    template: `<Finder :tree="tree" style="height: 100%" :filter="filterFunction"></Finder>`,
+    template: `<Finder
+      :tree="tree"
+      style="height: 100%"
+      :filter="filterFunction" />`,
     created() {
       this.tree = {
         id: "test",
@@ -121,6 +124,9 @@ storiesOf("Finder", module)
     props: {
       filter: {
         default: text("Filter", "")
+      },
+      autoSelectChildren: {
+        default: boolean("Auto select children", false)
       }
     },
     computed: {
@@ -135,7 +141,13 @@ storiesOf("Finder", module)
         return (item1, item2) => item1.label.localeCompare(item2.label);
       }
     },
-    template: `<Finder :tree="tree" :selectable="true" style="height: 100%" :filter="filterFunction" :sortBy="sortBy"></Finder>`,
+    template: `<Finder
+      :tree="tree"
+      :selectable="true"
+      :autoSelectChildren="autoSelectChildren"
+      style="height: 100%"
+      :filter="filterFunction"
+      :sortBy="sortBy" />`,
     created() {
       this.tree = data;
     }

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -125,8 +125,11 @@ storiesOf("Finder", module)
       filter: {
         default: text("Filter", "")
       },
-      autoSelectChildren: {
-        default: boolean("Auto select children", false)
+      autoSelectDescendants: {
+        default: boolean("Auto select descendants", false)
+      },
+      autoDeselectDescendants: {
+        default: boolean("Auto deselect descendants", false)
       }
     },
     computed: {
@@ -144,7 +147,8 @@ storiesOf("Finder", module)
     template: `<Finder
       :tree="tree"
       :selectable="true"
-      :autoSelectChildren="autoSelectChildren"
+      :autoSelectDescendants="autoSelectDescendants"
+      :autoDeselectDescendants="autoDeselectDescendants"
       style="height: 100%"
       :filter="filterFunction"
       :sortBy="sortBy" />`,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] All tests are passing
- [x] New/updated tests are included

This PR adds two props:

* `autoSelectDescendants`: Whether all its descendants should be automatically selected when an item is selected.
* `autoDeselectDescendants`: Whether all its descendants should be automatically deselected when an item is selected.

Closes #128 