### PR TITLE
fix: fix validation of drag-enabled prop to avoid Vue warnings

### DIFF
--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -81,8 +81,8 @@ export default {
       default: false
     },
     dragEnabled: {
-      type: Boolean,
-      default: Boolean
+      type: [Boolean, Function],
+      default: false
     },
     options: {
       type: Object,


### PR DESCRIPTION
This MR fixes warning below, in 2.x branch:

```
[Vue warn]: Invalid prop: type check failed for prop "dragEnabled". Expected Boolean, got Function.
```