### PR TITLE
perf: avoid update when expanding same node

### DIFF
--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -425,6 +425,19 @@ describe("Finder", () => {
           ]
         ]);
       });
+
+      it("should not emit the `expand` event when expanding the already expanded node", async () => {
+        const wrapper = mount(Finder, {
+          propsData: {
+            tree,
+            selectable: true,
+            defaultExpanded: "test112"
+          }
+        });
+
+        wrapper.vm.expand("test112");
+        expect(wrapper.emitted().expand).toBeFalsy();
+      });
     });
   });
 });

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -120,6 +120,9 @@ export default class extends EventManager {
    * @param {string} sourceEvent Name of the event that triggered the expand
    */
   expandNode(nodeId, sourceEvent) {
+    if (this.expanded && nodeId === this.expanded[this.expanded.length - 1]) {
+      return;
+    }
     this.expanded = path(nodeId, this.nodesMap);
     this.expandedWithoutFilter = this.expanded;
     this._updateVisibleTree();


### PR DESCRIPTION
This PR early returns when `update` tries to expand the already expanded node