### PR TITLE
perf: do not refresh when expanding already selected  node

### DIFF
--- a/src/components/__tests__/Finder.test.js
+++ b/src/components/__tests__/Finder.test.js
@@ -492,6 +492,21 @@ describe("Finder", () => {
         ]);
       });
 
+      it("should not emit the `expand` event when expanding the already expanded node", async () => {
+        const wrapper = mount(Finder, {
+          propsData: {
+            tree,
+            selectable: true,
+            defaultExpanded: "test112",
+          },
+        });
+
+        wrapper.vm.expand("test112");
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted().expand).toBeFalsy();
+      });
+
       it("should accept a 'sourceEvent' argument", async () => {
         const wrapper = mount(Finder, {
           props: {

--- a/src/utils/tree-model.js
+++ b/src/utils/tree-model.js
@@ -125,6 +125,9 @@ export default class extends EventManager {
    * @param {string} sourceEvent Name of the event that triggered the expand
    */
   expandNode(nodeId, sourceEvent) {
+    if (this.expanded && nodeId === this.expanded[this.expanded.length - 1]) {
+      return;
+    }
     this.expanded = path(nodeId, this.nodesMap);
     this.expandedWithoutFilter = this.expanded;
     this._updateVisibleTree();


### PR DESCRIPTION
This PR early returns when `expand` tries to expand the already expanded node
