### PR TITLE
feat(virtualization): add virtualize prop

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,9 @@
 import Vue from "vue";
 
 Vue.config.productionTip = false;
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));

--- a/src/components/Finder.vue
+++ b/src/components/Finder.vue
@@ -240,7 +240,27 @@ export default {
     scrollAnimationDuration: {
       type: Number,
       default: 200
+    },
+    /**
+     * Enable list virtualization of the tree.
+     */
+    virtualize: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Height of items, used for calculating the height of the virtualized list.
+     */
+    itemHeight: {
+      type: Number,
+      default: 44
     }
+  },
+  provide() {
+    return {
+      virtualize: this.virtualize,
+      itemHeight: this.itemHeight
+    };
   },
   data() {
     return {

--- a/src/components/FinderList.vue
+++ b/src/components/FinderList.vue
@@ -3,14 +3,8 @@ import { get } from "lodash-es";
 import FinderItem from "./FinderItem";
 import FinderListDropZone from "./FinderListDropZone";
 
-function renderItems(h, { props, expandedItemIndex }) {
-  let { items, options } = props;
-
-  if (options.sortBy) {
-    items = [...items].sort(options.sortBy);
-  }
-
-  return items.map((item, index) => [
+function renderItem(h, { props, item, index, expandedItemIndex }) {
+  return [
     ...[
       props.dragEnabled && (
         <FinderListDropZone
@@ -25,6 +19,7 @@ function renderItems(h, { props, expandedItemIndex }) {
     ],
 
     <FinderItem
+      ref={`item-${item.id}`}
       key={`item-${item.id}`}
       node={item}
       treeModel={props.treeModel}
@@ -35,7 +30,7 @@ function renderItems(h, { props, expandedItemIndex }) {
     >
       {item.label}
     </FinderItem>
-  ]);
+  ];
 }
 
 function getPreviousItemElement(element) {
@@ -62,7 +57,11 @@ function getNextItemElement(element) {
 
 export default {
   name: "FinderList",
-  functional: true,
+  components: {
+    FinderItem,
+    FinderListDropZone
+  },
+  inject: ["virtualize", "itemHeight"],
   props: {
     parent: {
       type: Object,
@@ -93,20 +92,76 @@ export default {
       default: false
     }
   },
-  render(h, { props, listeners }) {
-    const separatorColor = get(props, "options.theme.separatorColor", "");
-    const separatorWidth = get(props, "options.theme.separatorWidth", "");
-    const style = {
-      ...(separatorColor && { borderColor: separatorColor }),
-      ...(separatorWidth && { borderWidth: separatorWidth })
+  data() {
+    return {
+      listWidth: null,
+      visibleStart: null,
+      visibleEnd: null
     };
+  },
+  computed: {
+    sortedItems() {
+      return this.options.sortBy
+        ? [...this.items].sort(this.options.sortBy)
+        : this.items;
+    },
+    topOffset() {
+      return this.visibleStart * this.itemHeight;
+    },
+    bottomOffset() {
+      return (this.items.length - this.visibleEnd) * this.itemHeight;
+    },
+    style() {
+      const separatorColor = get(this.options, "theme.separatorColor", "");
+      const separatorWidth = get(this.options, "theme.separatorWidth", "");
+      return {
+        ...(separatorColor && { borderColor: separatorColor }),
+        ...(separatorWidth && { borderWidth: separatorWidth })
+      };
+    },
+    expandedItemIndex() {
+      return Math.max(
+        0,
+        this.sortedItems.findIndex(item =>
+          this.treeModel.isNodeExpanded(item.id)
+        )
+      );
+    }
+  },
+  watch: {
+    parent: {
+      immediate: true,
+      handler(newParent, oldParent) {
+        if (newParent.id !== oldParent?.id && this.$el) {
+          this.$el.scrollTop = 0;
+          this.updateVisibleRange();
+        }
+      }
+    },
+    "items.length": {
+      handler() {
+        this.updateVisibleRange();
+      }
+    }
+  },
+  mounted() {
+    this.updateVisibleRange();
 
-    const expandedItemIndex = Math.max(
-      0,
-      props.items.findIndex(item => props.treeModel.isNodeExpanded(item.id))
-    );
+    const resizeObserver = new ResizeObserver(() => {
+      this.updateVisibleRange();
+    });
 
-    function navigate(event) {
+    resizeObserver.observe(this.$el);
+
+    this.$el.addEventListener("keydown", this.navigate);
+  },
+  destroyed() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+  },
+  methods: {
+    navigate(event) {
       let sibling;
       if (event.key === "ArrowDown") {
         sibling = getNextItemElement(event.target);
@@ -117,24 +172,105 @@ export default {
       if (sibling) {
         sibling.focus();
       }
+    },
+    onScroll() {
+      if (!this.virtualize || this.isUpdatingVisibleRange) {
+        return;
+      }
+
+      window.requestAnimationFrame(() => {
+        this.updateVisibleRange();
+        this.isUpdatingVisibleRange = false;
+      });
+
+      this.isUpdatingVisibleRange = true;
+    },
+    getOffset() {
+      Math.floor(this.$el.scrollTop / this.itemHeight) + 1;
+    },
+    getVirtualRange() {
+      const overscan = 5;
+      const start = Math.max(
+        0,
+        Math.floor(this.$el.scrollTop / this.itemHeight) + 1 - overscan
+      );
+      const capacity = Math.ceil(this.$el.clientHeight / this.itemHeight);
+      const end = Math.min(start + capacity + overscan, this.items.length);
+
+      return { start, end };
+    },
+    async updateVisibleRange() {
+      const { start, end } = this.getVirtualRange();
+
+      if (start !== this.visibleStart) {
+        this.visibleStart = start;
+      }
+
+      if (end !== this.visibleEnd) {
+        this.visibleEnd = end;
+      }
+
+      await this.$nextTick();
+
+      // We could have lost focus on focused item while updating the visible range
+      // so we need to refocus it
+      const focusedItem = this.$refs[`item-${this.treeModel.focusedNodeId}`];
+      if (
+        focusedItem &&
+        focusedItem.$el &&
+        focusedItem.$el !== document.activeElement
+      ) {
+        focusedItem.$el.focus({
+          preventScroll: true
+        });
+      }
     }
+  },
+  render(h) {
+    const expandedItemIndex = Math.max(
+      0,
+      this.sortedItems.findIndex(item => this.treeModel.isNodeExpanded(item.id))
+    );
+
+    const isVisible = index =>
+      !this.virtualize ||
+      (index >= this.visibleStart && index <= this.visibleEnd);
 
     return [
-      <div class="list" style={style} vOn:keydown={navigate}>
+      <div class="list" style={this.style} vOn:scroll={this.onScroll}>
         {[
-          ...renderItems(h, { props, listeners, expandedItemIndex }),
+          ...(this.virtualize
+            ? [<div style={{ flexShrink: 0, height: `${this.topOffset}px` }} />]
+            : []),
+          ...this.sortedItems.map(
+            (item, index) =>
+              isVisible(index) &&
+              renderItem(h, {
+                props: this.$props,
+                item,
+                index,
+                expandedItemIndex
+              })
+          ),
           ...[
-            props.dragEnabled && (
+            this.dragEnabled && (
               <FinderListDropZone
                 class="last"
-                treeModel={props.treeModel}
-                node={props.parent}
-                dragEnabled={props.dragEnabled}
-                index={props.items.length}
-                options={props.options}
+                treeModel={this.treeModel}
+                node={this.parent}
+                dragEnabled={this.dragEnabled}
+                index={this.items.length}
+                options={this.options}
               />
             )
-          ]
+          ],
+          ...(this.virtualize
+            ? [
+                <div
+                  style={{ flexShrink: 0, height: `${this.bottomOffset}px` }}
+                />
+              ]
+            : [])
         ]}
       </div>
     ];

--- a/src/components/FinderListDropZone.vue
+++ b/src/components/FinderListDropZone.vue
@@ -54,13 +54,12 @@ export default {
       default: () => ({})
     }
   },
-  data: () => ({
-    dragCounter: 0
-  }),
   computed: {
     dragOver() {
       return (
-        this.treeModel.isDragging() && this.canDrop && this.dragCounter > 0
+        this.treeModel.isDragging() &&
+        this.canDrop &&
+        this.treeModel.isDragOver(this.dropzoneId)
       );
     },
     theme() {
@@ -82,18 +81,23 @@ export default {
         !this.options.canDrop ||
         this.options.canDrop(this.node.id, this.treeModel.draggedNodeId)
       );
+    },
+    dropzoneId() {
+      return `drop-zone-${this.node.id}${
+        this.index ? `____i${this.index}` : ""
+      }`;
     }
   },
   methods: {
     onDragEnter() {
-      this.dragCounter++;
+      this.treeModel.onDragEnter(this.dropzoneId);
     },
     onDragLeave() {
-      this.dragCounter--;
+      this.treeModel.onDragLeave(this.dropzoneId);
     },
     onDrop(event) {
       event.preventDefault();
-      this.dragCounter = 0;
+      this.treeModel.dragReset();
       if (!this.canDrop || !this.treeModel.isDragging()) {
         return;
       }

--- a/src/components/__tests__/FinderItem.test.js
+++ b/src/components/__tests__/FinderItem.test.js
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import TreeModel from "@/utils/tree-model";
 import FinderItem from "../FinderItem";
 
-jest.mock("@/utils/tree-model");
 jest.useFakeTimers();
 
 describe("FinderItem", () => {
@@ -46,8 +45,12 @@ describe("FinderItem", () => {
   });
 
   describe("Expand", () => {
+    beforeEach(() => {
+      jest.spyOn(treeModel, "expandNode");
+    });
+
     it("should match snapshot if expanded", () => {
-      treeModel.isNodeExpanded.mockReturnValue(true);
+      treeModel.expandNode("test111");
       const wrapper = mount(FinderItem, {
         propsData: {
           treeModel,
@@ -99,6 +102,10 @@ describe("FinderItem", () => {
   });
 
   describe("Selection", () => {
+    beforeEach(() => {
+      jest.spyOn(treeModel, "selectNode");
+    });
+
     it("should match snapshot if selectable", () => {
       const wrapper = mount(FinderItem, {
         propsData: {
@@ -124,7 +131,7 @@ describe("FinderItem", () => {
     });
 
     it("should call treeModel.selectNode on click on checked checkbox", async () => {
-      treeModel.isNodeSelected.mockReturnValue(true);
+      treeModel.selectNode("test111", true);
       const wrapper = mount(FinderItem, {
         propsData: {
           treeModel,
@@ -173,7 +180,11 @@ describe("FinderItem", () => {
     });
 
     describe("dragstart", () => {
-      it("should call treeModel.startDrag", () => {
+      beforeEach(() => {
+        jest.spyOn(treeModel, "startDrag");
+      });
+
+      it("should call treeModel.startDrag", async () => {
         const dataTransfer = {
           setDragImage: jest.fn(),
           setData: jest.fn()
@@ -186,7 +197,7 @@ describe("FinderItem", () => {
           }
         });
 
-        wrapper.trigger("dragstart", {
+        await wrapper.trigger("dragstart", {
           dataTransfer
         });
 
@@ -283,7 +294,8 @@ describe("FinderItem", () => {
 
     describe("dragenter", () => {
       beforeEach(() => {
-        treeModel.isDragging.mockReturnValue(true);
+        treeModel.startDrag("test12");
+        jest.spyOn(treeModel, "expandNode");
       });
 
       it("should call treeModel.expandNode", async () => {
@@ -436,6 +448,10 @@ describe("FinderItem", () => {
     });
 
     describe("dragend", () => {
+      beforeEach(() => {
+        jest.spyOn(treeModel, "stopDrag");
+      });
+
       it("should call treeModel.stopDrag", async () => {
         const wrapper = mount(FinderItem, {
           propsData: {

--- a/src/components/__tests__/FinderList.test.js
+++ b/src/components/__tests__/FinderList.test.js
@@ -6,6 +6,7 @@ jest.mock("@/utils/tree-model");
 
 describe("FinderList", () => {
   let treeModel;
+  let provide;
   const tree = {
     id: "test1",
     children: [
@@ -34,6 +35,10 @@ describe("FinderList", () => {
   };
   beforeEach(() => {
     treeModel = new TreeModel(tree);
+    provide = {
+      virtualize: false,
+      itemHeight: 45
+    };
   });
 
   it("should match snapshot", () => {
@@ -41,7 +46,8 @@ describe("FinderList", () => {
       propsData: {
         treeModel,
         items: tree.children
-      }
+      },
+      provide
     });
     expect(wrapper).toMatchSnapshot();
   });
@@ -50,7 +56,8 @@ describe("FinderList", () => {
     const wrapper = mount(FinderList, {
       propsData: {
         treeModel
-      }
+      },
+      provide
     });
     expect(wrapper).toMatchSnapshot();
   });
@@ -61,7 +68,8 @@ describe("FinderList", () => {
         treeModel,
         items: tree.children,
         dragEnabled: true
-      }
+      },
+      provide
     });
     expect(wrapper).toMatchSnapshot();
   });
@@ -72,7 +80,8 @@ describe("FinderList", () => {
         treeModel,
         items: tree.children,
         selectable: true
-      }
+      },
+      provide
     });
     expect(wrapper).toMatchSnapshot();
   });
@@ -83,7 +92,8 @@ describe("FinderList", () => {
         treeModel,
         items: tree.children
       },
-      attachTo: document.body
+      attachTo: document.body,
+      provide
     });
 
     const firstItem = wrapper.findAll(".item").at(0);
@@ -112,7 +122,8 @@ describe("FinderList", () => {
         items: tree.children,
         dragEnabled: true
       },
-      attachTo: document.body
+      attachTo: document.body,
+      provide
     });
 
     const firstItem = wrapper.findAll(".item").at(0);
@@ -132,5 +143,22 @@ describe("FinderList", () => {
     // Up navigates back to the first item
     secondItem.trigger("keydown", { key: "ArrowUp" });
     expect(document.activeElement).toBe(firstItem.element);
+  });
+
+  it("should handle virtualize option", async () => {
+    provide.virtualize = true;
+    const wrapper = mount(FinderList, {
+      propsData: {
+        treeModel,
+        items: tree.children,
+        dragEnabled: true
+      },
+      attachTo: document.body,
+      provide
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.vm.visibleStart).toBe(0);
+    expect(wrapper.vm.visibleEnd).toBe(2);
   });
 });

--- a/src/components/__tests__/FinderListDropZone.test.js
+++ b/src/components/__tests__/FinderListDropZone.test.js
@@ -2,8 +2,6 @@ import { mount } from "@vue/test-utils";
 import TreeModel from "@/utils/tree-model";
 import FinderListDropZone from "../FinderListDropZone";
 
-jest.mock("@/utils/tree-model");
-
 describe("FinderListDropZone", () => {
   let treeModel;
   let node;
@@ -45,7 +43,7 @@ describe("FinderListDropZone", () => {
   });
 
   it("should match if drag enter and is dragging", async () => {
-    treeModel.isDragging.mockReturnValue(true);
+    treeModel.startDrag("test12");
     const wrapper = mount(FinderListDropZone, {
       propsData: {
         treeModel,
@@ -53,14 +51,22 @@ describe("FinderListDropZone", () => {
         dragEnabled: true
       }
     });
+
     wrapper.trigger("dragenter");
+    expect(treeModel.dragCounter.counter).toBe(1);
+    expect(treeModel.dragCounter.enteredDropzoneId).toBe("drop-zone-test111");
+    expect(wrapper.vm.dropzoneId).toBe("drop-zone-test111");
+    expect(treeModel.isDragging()).toBe(true);
+    expect(wrapper.vm.canDrop).toBe(true);
+    expect(wrapper.vm.dragOver).toBe(true);
+
     await wrapper.vm.$nextTick();
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("should match if drag leave and is dragging", async () => {
-    treeModel.isDragging.mockReturnValue(true);
+    treeModel.startDrag("test12");
     const wrapper = mount(FinderListDropZone, {
       propsData: {
         treeModel,
@@ -68,6 +74,7 @@ describe("FinderListDropZone", () => {
         dragEnabled: true
       }
     });
+
     wrapper.trigger("dragenter");
     wrapper.trigger("dragleave");
     await wrapper.vm.$nextTick();
@@ -76,7 +83,6 @@ describe("FinderListDropZone", () => {
   });
 
   it("should match if drag enter and not dragging", async () => {
-    treeModel.isDragging.mockReturnValue(false);
     const wrapper = mount(FinderListDropZone, {
       propsData: {
         treeModel,
@@ -90,7 +96,6 @@ describe("FinderListDropZone", () => {
   });
 
   it("should match if drag leave and not dragging", async () => {
-    treeModel.isDragging.mockReturnValue(false);
     const wrapper = mount(FinderListDropZone, {
       propsData: {
         treeModel,
@@ -105,8 +110,11 @@ describe("FinderListDropZone", () => {
   });
 
   describe("#onDrop", () => {
+    beforeEach(() => {
+      jest.spyOn(treeModel, "dropOnNode");
+    });
     it("should call `treeModel.dropOnNode`", () => {
-      treeModel.isDragging.mockReturnValue(true);
+      treeModel.startDrag("test12");
       const wrapper = mount(FinderListDropZone, {
         propsData: {
           treeModel,
@@ -119,7 +127,8 @@ describe("FinderListDropZone", () => {
     });
 
     it("should call `treeModel.dropOnNode` with index", () => {
-      treeModel.isDragging.mockReturnValue(true);
+      treeModel.startDrag("test12");
+
       const wrapper = mount(FinderListDropZone, {
         propsData: {
           treeModel,
@@ -132,8 +141,7 @@ describe("FinderListDropZone", () => {
       expect(treeModel.dropOnNode).toHaveBeenCalledWith("test111", 5);
     });
 
-    it("should not call `treeModel.dropOnNode` if not dragging", () => {
-      treeModel.isDragging.mockReturnValue(false);
+    it("should not call `treeModel.dropOnNode` if not dragging", async () => {
       const wrapper = mount(FinderListDropZone, {
         propsData: {
           treeModel,
@@ -141,7 +149,7 @@ describe("FinderListDropZone", () => {
           dragEnabled: true
         }
       });
-      wrapper.trigger("drop");
+      await wrapper.trigger("drop");
       expect(treeModel.dropOnNode).not.toHaveBeenCalled();
     });
   });

--- a/src/components/__tests__/__snapshots__/FinderList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FinderList.test.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FinderList should handle virtualize option 1`] = `
+<div class="list">
+  <div style="flex-shrink: 0; height: 0px;"></div>
+  <div class="drop-zone">
+    <!---->
+  </div>
+  <div role="button" draggable="true" class="item draggable" tabindex="0">
+    <!---->
+    <!---->
+    <div item="[object Object]" class="inner-item">Test 11</div>
+    <div class="arrow"></div>
+  </div>
+  <div class="drop-zone last">
+    <!---->
+  </div>
+  <div style="flex-shrink: 0; height: 90px;"></div>
+</div>
+`;
+
 exports[`FinderList should match snapshot 1`] = `
 <div class="list">
   <div role="button" draggable="false" class="item" tabindex="0">

--- a/src/utils/__tests__/drag-counter.test.js
+++ b/src/utils/__tests__/drag-counter.test.js
@@ -1,0 +1,75 @@
+import DragCounter from "../drag-counter";
+
+describe("DragCounter", () => {
+  let dragCounter;
+
+  beforeEach(() => {
+    dragCounter = new DragCounter();
+  });
+
+  describe("#constructor", () => {
+    it("should initialize the instance", () => {
+      expect(dragCounter.counter).toBe(0);
+      expect(dragCounter.enteredDropzoneId).toBeUndefined();
+    });
+  });
+
+  describe("#onDragEnter", () => {
+    it("should increment counter", () => {
+      dragCounter.onDragEnter("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(1);
+      expect(dragCounter.enteredDropzoneId).toBe("myDropzoneId");
+
+      dragCounter.onDragEnter("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(2);
+      expect(dragCounter.enteredDropzoneId).toBe("myDropzoneId");
+    });
+  });
+
+  describe("#onDragLeave", () => {
+    it("should decrement counter", () => {
+      dragCounter.counter = 2;
+      dragCounter.enteredDropzoneId = "myDropzoneId";
+
+      dragCounter.onDragLeave("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(1);
+      expect(dragCounter.enteredDropzoneId).toBe("myDropzoneId");
+
+      dragCounter.onDragLeave("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(0);
+      expect(dragCounter.enteredDropzoneId).toBeUndefined();
+
+      dragCounter.onDragLeave("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(0);
+      expect(dragCounter.enteredDropzoneId).toBeUndefined();
+    });
+
+    it("should not set counter < 0", () => {
+      dragCounter.counter = 1;
+      dragCounter.enteredDropzoneId = "myDropzoneId";
+
+      dragCounter.onDragLeave("myDropzoneId");
+      dragCounter.onDragLeave("myDropzoneId");
+
+      expect(dragCounter.counter).toBe(0);
+      expect(dragCounter.enteredDropzoneId).toBeUndefined();
+    });
+  });
+
+  describe("#reset", () => {
+    it("should reset the instance", () => {
+      dragCounter.counter = 3;
+      dragCounter.enteredDropzoneId = "myDropzoneId";
+
+      dragCounter.reset();
+
+      expect(dragCounter.counter).toBe(0);
+      expect(dragCounter.enteredDropzoneId).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/drag-counter.js
+++ b/src/utils/drag-counter.js
@@ -1,0 +1,43 @@
+export default class {
+  constructor() {
+    this.counter = 0;
+    this.enteredDropzoneId = undefined;
+  }
+
+  /**
+   * Add a given node in the set of nodes that are currently entered.
+   *
+   * @param {*} node
+   * @returns `true` if the node was the first one to be entered
+   */
+  onDragEnter(dropzoneId) {
+    this.counter++;
+    this.enteredDropzoneId = dropzoneId;
+  }
+
+  /**
+   * Remove a given node from the set of nodes that are currently entered.
+   *
+   * @param {*} node
+   * @returns `true` if the node was the last one to be leaved
+   */
+  onDragLeave(dropzoneId) {
+    if (dropzoneId !== this.enteredDropzoneId) {
+      return;
+    }
+
+    this.counter--;
+
+    if (this.counter === 0) {
+      this.enteredDropzoneId = undefined;
+    }
+  }
+
+  /**
+   * Reset the set of nodes that are currently entered.
+   */
+  reset() {
+    this.enteredDropzoneId = undefined;
+    this.counter = 0;
+  }
+}

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,7 +1,7 @@
 import Finder from "../src/components/Finder";
 
-const MAX_DEPTH = 4;
-const CHILDREN_NUMBER = 10;
+const MAX_DEPTH = 1;
+const CHILDREN_NUMBER = 50;
 
 function createChildren(parentId, parentLabel, parentIndex, parentDepth) {
   const children = [];
@@ -135,7 +135,10 @@ const defaultArgs = {
 export const LotOfItems = Template.bind({});
 LotOfItems.args = {
   ...defaultArgs,
-  tree: null
+  tree: null,
+  dragEnabled: true,
+  virtualize: true,
+  itemHeight: 44
 };
 LotOfItems.loaders = [
   async () => ({
@@ -218,3 +221,21 @@ CustomTheme.args = {
   }
 };
 CustomTheme.storyName = "Custom theme";
+
+export const Virtualization = Template.bind({});
+Virtualization.args = {
+  ...defaultArgs,
+  tree: null,
+  virtualize: true,
+  itemHeight: 44
+};
+Virtualization.loaders = [
+  async () => ({
+    loadedTree: {
+      id: "test",
+      label: "Test",
+      children: createChildren("test", "Test", 0, 0)
+    }
+  })
+];
+Virtualization.storyName = "With virtualization";

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,7 +1,7 @@
 import Finder from "../src/components/Finder";
 
-const MAX_DEPTH = 1;
-const CHILDREN_NUMBER = 50;
+const MAX_DEPTH = 4;
+const CHILDREN_NUMBER = 10;
 
 function createChildren(parentId, parentLabel, parentIndex, parentDepth) {
   const children = [];
@@ -135,10 +135,7 @@ const defaultArgs = {
 export const LotOfItems = Template.bind({});
 LotOfItems.args = {
   ...defaultArgs,
-  tree: null,
-  dragEnabled: true,
-  virtualize: true,
-  itemHeight: 44
+  tree: null
 };
 LotOfItems.loaders = [
   async () => ({
@@ -226,6 +223,7 @@ export const Virtualization = Template.bind({});
 Virtualization.args = {
   ...defaultArgs,
   tree: null,
+  dragEnabled: true,
   virtualize: true,
   itemHeight: 44
 };


### PR DESCRIPTION
This PR adds `virtualize` and `itemHeight` props that enables list virtualization.

- `virtualize: true` enables virtualization, so a more performant rendering when some nodes contains a lot of children
- `itemHeight` is used to estimate the height of lists when virtualization is enabled

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
