### PR TITLE
fix: allow to drop on items that cannot be dragged

### DIFF
--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -165,7 +165,7 @@ export default {
       this.treeModel.startDrag(this.node.id);
     },
     onDragOver(event) {
-      if (!this.canDrag) {
+      if (!this.dragEnabled) {
         return;
       }
 
@@ -182,7 +182,7 @@ export default {
         this.ghost.parentNode.removeChild(this.ghost);
         this.ghost = null;
       }
-      if (!this.canDrag) {
+      if (!this.dragEnabled) {
         return;
       }
 

--- a/src/components/__tests__/FinderItem.test.js
+++ b/src/components/__tests__/FinderItem.test.js
@@ -445,6 +445,26 @@ describe("FinderItem", () => {
 
         expect(dataTransfer.dropEffect).toBeUndefined();
       });
+
+      it("should set dataTransfer.dropEffect = `all` if `dragEnabled` is a function returning `false`", async () => {
+        const dataTransfer = {};
+        const wrapper = mount(FinderItem, {
+          propsData: {
+            treeModel,
+            node,
+            dragEnabled: () => false,
+            options: {
+              canDrop: () => true
+            }
+          }
+        });
+
+        await wrapper.trigger("dragover", {
+          dataTransfer
+        });
+
+        expect(dataTransfer.dropEffect).toBe("move");
+      });
     });
 
     describe("dragend", () => {


### PR DESCRIPTION
This PR allows to drop items on items that cannot be dragged by passing a function as `dragEnabled`.